### PR TITLE
Migrated from deprecated apply method to declarative plugins block for Gradle plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,17 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.9.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.14'
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,16 +5,22 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-    plugins {
-        id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 
-include ":app"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.3.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "com.google.gms.google-services" version "4.3.14" apply false
+}
 
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+include ":app"


### PR DESCRIPTION
## Resolves #62 :
- Replaced the deprecated apply script method for app_plugin_loader in the android/build.gradle file with the declarative plugins block as recommended by Flutter's Gradle plugin migration guide.
- Ensures future compatibility with upcoming Gradle releases by adopting the new syntax for applying plugins.